### PR TITLE
Improve frontend navigation

### DIFF
--- a/frontend/src/components/layout/Layout.jsx
+++ b/frontend/src/components/layout/Layout.jsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+export default function Layout({ children }) {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <nav className="bg-white shadow">
+        <div className="max-w-5xl mx-auto px-4 py-3 flex space-x-4">
+          <Link href="/" className="font-semibold hover:underline">
+            Inicio
+          </Link>
+          <Link href="/flats" className="font-semibold hover:underline">
+            Pisos
+          </Link>
+          <Link href="/register" className="font-semibold hover:underline">
+            Registro
+          </Link>
+          <Link
+            href="/host/dashboard"
+            className="font-semibold hover:underline"
+          >
+            Dashboard Anfitrión
+          </Link>
+        </div>
+      </nav>
+      <main className="max-w-5xl mx-auto px-4 py-6">{children}</main>
+    </div>
+  );
+}

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -1,0 +1,10 @@
+import '../styles/globals.css';
+import Layout from '../components/layout/Layout';
+
+export default function MyApp({ Component, pageProps }) {
+  return (
+    <Layout>
+      <Component {...pageProps} />
+    </Layout>
+  );
+}

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,11 +1,21 @@
 // frontend/src/pages/index.js
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
+import Link from 'next/link';
 
-export default function HomeRedirect() {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace('/flats');
-  }, [router]);
-  return null;
+export default function Home() {
+  return (
+    <div className="text-center mt-10">
+      <h1 className="text-4xl font-bold mb-4">
+        Bienvenido a Erasmus Flatshare
+      </h1>
+      <p className="mb-6 text-lg">
+        Encuentra y gestiona alojamientos para tu experiencia Erasmus.
+      </p>
+      <Link
+        href="/flats"
+        className="bg-blue-500 hover:bg-blue-600 text-white px-6 py-3 rounded"
+      >
+        Ver Pisos Disponibles
+      </Link>
+    </div>
+  );
 }

--- a/frontend/src/styles/globals.css
+++ b/frontend/src/styles/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;


### PR DESCRIPTION
## Summary
- add global layout and navigation bar for all pages
- create a minimal global stylesheet with Tailwind
- implement a real home page with introductory text and link to flats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6841c6bb9364832ab315ca4e155c9fa8