### PR TITLE
Export knex and tear down after tests

### DIFF
--- a/backend/src/__tests__/flats.test.js
+++ b/backend/src/__tests__/flats.test.js
@@ -1,6 +1,6 @@
 // src/__tests__/flats.test.js
 const request = require('supertest');
-const app = require('../index');
+const { app, knex } = require('../index');
 
 describe('Flats API', () => {
   let userId;
@@ -46,5 +46,9 @@ describe('Flats API', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toHaveProperty('id', flatId);
     expect(res.body).toHaveProperty('host_id', userId);
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
   });
 });

--- a/backend/src/__tests__/reservations.test.js
+++ b/backend/src/__tests__/reservations.test.js
@@ -1,6 +1,6 @@
 // src/__tests__/reservations.test.js
 const request = require('supertest');
-const app = require('../index');
+const { app, knex } = require('../index');
 
 describe('Reservations API', () => {
   let userId;
@@ -76,5 +76,9 @@ describe('Reservations API', () => {
     const res = await request(app).put(`/api/reservations/${rid2}/deny`);
     expect(res.statusCode).toBe(200);
     expect(res.body).toHaveProperty('status', 'denegado');
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
   });
 });

--- a/backend/src/__tests__/users.test.js
+++ b/backend/src/__tests__/users.test.js
@@ -1,6 +1,6 @@
 // src/__tests__/users.test.js
 const request = require('supertest');
-const app = require('../index'); // ajusta si tu index.js está en otra ruta
+const { app, knex } = require('../index'); // ajusta si tu index.js está en otra ruta
 
 describe('Users API', () => {
   it('POST /api/users → crea un usuario y devuelve 201 y JSON', async () => {
@@ -18,5 +18,9 @@ describe('Users API', () => {
     expect(res.body.name).toBe('Prueba Jest');
     expect(res.body.instagram_handle).toBe('jest_test');
     expect(res.body.role).toBe('buscador');
+  });
+
+  afterAll(async () => {
+    await knex.destroy();
   });
 });

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -29,6 +29,6 @@ app.use('/api', reservationsRouter(knex));
      });
    }
   
-   // Exportamos el app para testing
-   module.exports = app;
+   // Exportamos el app y knex para testing
+   module.exports = { app, knex };
 


### PR DESCRIPTION
## Summary
- export the `knex` instance in `backend/src/index.js`
- import `app` and `knex` in test files
- clean up by destroying `knex` after the suites

## Testing
- `node node_modules/jest/bin/jest.js --detectOpenHandles --forceExit` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_6841c3ddcebc832a81a801a2f387e862