### PR TITLE
Fix reservation update state logic

### DIFF
--- a/frontend/src/pages/host/flats/[id].js
+++ b/frontend/src/pages/host/flats/[id].js
@@ -27,10 +27,14 @@ export default function FlatReservations() {
   const handleAction = async (rid, action) => {
     try {
       await axios.put(`http://localhost:5000/api/reservations/${rid}/${action}`);
-      // Refresca la lista
-      setReservations(reservations.map(r =>
-        r.id === rid ? { ...r, status: action === 'accept' ? 'aceptado' : 'denegado' } : r
-      ));
+      // Refresca la lista utilizando el estado más reciente
+      setReservations(prev =>
+        prev.map(r =>
+          r.id === rid
+            ? { ...r, status: action === 'accept' ? 'aceptado' : 'denegado' }
+            : r
+        )
+      );
     } catch (err) {
       console.error(`Error al ${action}:`, err);
     }


### PR DESCRIPTION
## Summary
- avoid stale state when updating reservation status on host page

## Testing
- `npm --prefix frontend test`
- `npm --prefix backend test` *(fails: jest Permission denied / DB connect errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841c230e2f4832a8fa51567cefcdd22